### PR TITLE
Update to permissions for "View Logs" and "Edit script files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build.sh
 .vscode
 dnsmasq.wbm*
 dnsmasq/help/dnsmasq*.txt
+*.rpm
+*.deb
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ To edit an item in the list, click on any of the values to show an edit dialog.
 
 To enable one or more list item, click the checkbox to the left of the item and click `Enable`. More than one item at a time may be enabled or disabled by checking more than one box.
 
+For most list values, the order is not important. However, for those configuration options for which order is important, an additional column is shown on the right-hand side showing up and down arrows. Click one of these arrows to move the corresponding item up or down, respectively. The items above or below will be reordered appropriately.
+
 ### Manual configuration file editing
 Finally, you may directly edit the configuration file(s) by clicking `Edit config files` under the `DNS settings` tab.
 

--- a/dnsmasq/dns.cgi
+++ b/dnsmasq/dns.cgi
@@ -79,7 +79,8 @@ sub show_dns_settings {
             "link" => "manual_edit.cgi?type=script",
             "title" => $text{"index_dns_scripts_edit"},
             "icon" => "manual.gif",
-            "page" => 10
+            "page" => 10,
+            "access" => "edit_scripts"
         },
         {
             "link" => "dnsmasq_control.cgi",
@@ -91,11 +92,13 @@ sub show_dns_settings {
             "link" => "view_log.cgi",
             "title" => $text{"index_dns_view_log"},
             "icon" => "logs.gif",
-            "page" => 12
+            "page" => 12,
+            "access" => "view_logs"
         },
     );
     local $i;
     for ($i = 0; $i < @buttons; $i++ ) {
+        next if ($buttons[$i]->{"access"} && !$access{$buttons[$i]->{"access"}});
         push(@links, $buttons[$i]->{"link"} );
         push(@titles, $buttons[$i]->{"title"} );
         push(@icons, "images/" . ($current_theme ? "theme/" : "") . $buttons[$i]->{"icon"} );

--- a/dnsmasq/lang/en
+++ b/dnsmasq/lang/en
@@ -20,6 +20,7 @@ acl_dump_logs=Can dump DNSmasq logs?
 acl_view_logs=Can view DNSmasq logs?
 acl_edit_hosts=Can edit /etc/hosts and other hosts files?
 acl_edit_scripts=Can edit scripts?
+edit_scripts_ecannot=You are not allowed to edit scripts
 
 stop_err=Failed to stop DNSmasq
 stop_ecannot=You are not allowed to stop DNSmasq

--- a/dnsmasq/manual_edit.cgi
+++ b/dnsmasq/manual_edit.cgi
@@ -26,23 +26,20 @@ my $config_file = &read_file_lines( $config_filename );
 
 &ReadParse();
 
-# $access{'types'} eq '*' && $access{'virts'} eq '*' ||
-# 	&error($text{'manual_ecannot'});
-# &ui_print_header(undef, $text{'index_dns_config_edit'}, "");
 
-# check for errors in read config
+my $returnto = $in{"returnto"} || "manual_edit.cgi?type=" . $type;
+my $returnlabel = $in{"returnlabel"} || $text{"index_dns_config_edit"};
 my $ch = defined($in{"ch"}) ? $in{"ch"} : -1;
 my $line = defined($in{"line"}) ? $in{"line"} : -1;
 my $file = $in{"file"};
 my $type = $in{"type"} || "config";
 my @files = ();
 if ($type eq "config") {
-    push( @files, @{ $dnsmconfig{"configfiles"} } );
+    # check for errors in read config
     my $error_message = "<div>";
     if( $dnsmconfig{"error"}) {
         $error_message .= "<h2>" . @{$dnsmconfig{"error"}} . " errors found in configuration</h2><br/><br/>";
         foreach my $e ( @{$dnsmconfig{"error"}} ) {
-            # $error_message .= "File: " . $e->{"file"} . " line: " . $e->{"line"} . "<br/>";
             if ($line == -1) {
                 $line = $e->{"line"};
                 $file = $e->{"file"};
@@ -57,11 +54,13 @@ if ($type eq "config") {
     print &header_style();
 
     print $error_message;
+    push( @files, @{ $dnsmconfig{"configfiles"} } );
 }
-else {
-    push( @files, @{ $dnsmconfig{"scripts"} });
+elsif ($type eq "script") {
     &ui_print_header($text{"index_dns_scripts_edit"}, $text{"index_title"}, "", "intro", 1, 0, 0, &restart_button());
     print &header_style();
+    $access{'edit_scripts'} || &error($text{'edit_scripts_ecannot'});
+    push( @files, @{ $dnsmconfig{"scripts"} });
 }
 $file = $files[0] if ($file eq "");
 
@@ -87,8 +86,7 @@ if ($line != -1) {
         . "  }, 5);\n"
         . "});\n"
 }
-print "\n"
-    . "function getPosition() {\n"
+print "function getPosition() {\n"
     . "  var line; var ch;\n"
     . "  for (var i in window) {\n"
     . "    if (i.startsWith(\"__cm_editor_\") && typeof window[i] == \"object\") {\n"
@@ -98,11 +96,8 @@ print "\n"
     . "  }\n"
     . "  \$('input[name=line]').attr('value', line + 1);\n"
     . "  \$('input[name=ch]').attr('value', ch + 1);\n"
-    . "}\n"
-    . "</script>\n";
-
-my $returnto = $in{"returnto"} || "manual_edit.cgi?type=" . $type;
-my $returnlabel = $in{"returnlabel"} || $text{"index_dns_config_edit"};
+    . "}\n";
+print "</script>\n";
 
 print "<form action=\"manual_edit.cgi\">\n";
 print "<input type=hidden name=\"type\" value=\"$type\">\n";

--- a/dnsmasq/manual_edit_save.cgi
+++ b/dnsmasq/manual_edit_save.cgi
@@ -29,8 +29,6 @@ my $config_file = &read_file_lines( $config_filename );
 my $type = $in{"type"} || "config";
 my $returnto = $in{"returnto"} || "manual_edit.cgi?type=" . $type . "&file=" . $in{'file'} . "&line=" . $in{'line'} . "&ch=" . $in{'ch'};
 my $returnlabel = $in{"returnlabel"} || $text{"index_dns_config_edit"};
-# $access{'types'} eq '*' && $access{'virts'} eq '*' ||
-# 	&error($text{'manual_ecannot'});
 
 my @files = ();
 if ($type eq "config") {


### PR DESCRIPTION
If the user doesn't have permissions to view logs and/or edit scripts, the corresponding icon is no longer shown under `DNS settings`. Additionally, if the user lacks these permissions, the corresponding page will show only an error explaining such.