### PR TITLE
Native user & group validation

### DIFF
--- a/dnsmasq/lang/en
+++ b/dnsmasq/lang/en
@@ -20,6 +20,7 @@ acl_dump_logs=Can dump DNSmasq logs?
 acl_view_logs=Can view DNSmasq logs?
 acl_edit_hosts=Can edit /etc/hosts and other hosts files?
 acl_edit_scripts=Can edit scripts?
+
 edit_scripts_ecannot=You are not allowed to edit scripts
 
 stop_err=Failed to stop DNSmasq

--- a/dnsmasq/view_log.cgi
+++ b/dnsmasq/view_log.cgi
@@ -17,6 +17,8 @@
 
 require './dnsmasq-lib.pl';
 
+$access{"view_logs"} || &error($text{"view_logs_ecannot"});
+
 # read config file
 my $config_filename = $config{config_file};
 my $config_file = &read_file_lines( $config_filename );


### PR DESCRIPTION
Replaces username & groupname validation to use `useradmin` methods, instead of custom methods that expect non-existent permissions.

Also a minor update to permission checking for the `view_log.cgi` page.